### PR TITLE
Zsh compatibility

### DIFF
--- a/ginh.sh
+++ b/ginh.sh
@@ -4,7 +4,9 @@ declare -a counts freq cmds
 line_len=`expr $(/usr/bin/tput cols) - 2` # get terminal width
 num_entries=15
 chart_char='='
-histfile="$HOME/.bash_history"
+# Get the calling shell
+shell=$(ps -o comm=$PPID | grep $(echo $0 | cut -d"/" -f2-) -B 1 | head -1)
+histfile=$($shell -ci "echo \$HISTFILE")
 OPTIND=1 # reset getopts
 max_len=0
 
@@ -81,14 +83,14 @@ do
     printf " "
   done
   printf "%s " $(echo ${cmds[$n]} | cut -d' ' -f2-)
-  
+
   for (( m=0; m<=freq[$n]; m++ ))
   do
     printf "$chart_char"
   done
   printf "  "
   printf "%s" $(echo ${cmds[$n]} | awk '{print $1}')
-  
+
   printf "\n"
 done
 

--- a/ginh.sh
+++ b/ginh.sh
@@ -54,7 +54,14 @@ shift $((OPTIND-1))
 
 echo "entries=$num_entries, file=$histfile, char=$chart_char, len=$line_len"
 
-calc=$(grep -v -E '^\s*$|^\s+' $histfile | awk '{print $1}' | sort | uniq -c | sort -rn)
+if [ $zsh_extended_history -eq 1 ]
+then
+  calc=$(grep -v -E '^\s*$|^\s+' $histfile | awk -F ';' '{print $2}' |
+    awk '{print $1}' | sort | uniq -c | sort -rn)
+else
+  calc=$(grep -v -E '^\s*$|^\s+' $histfile | awk '{print $1}' | sort | uniq -c |
+    sort -rn)
+fi
 
 for (( n=0; n<=$num_entries; n++ ))
 # gather counts and cmds

--- a/ginh.sh
+++ b/ginh.sh
@@ -11,7 +11,7 @@ OPTIND=1 # reset getopts
 max_len=0
 
 # check for zsh extended history format style
-$shell -ci "setopt" |& grep extendedhistory >/dev/null
+$shell -ci "setopt" 2>&1 | grep extendedhistory >/dev/null
 zsh_extended_history=$(expr 1 - $?)
 
 function show_help {

--- a/ginh.sh
+++ b/ginh.sh
@@ -5,7 +5,7 @@ line_len=`expr $(/usr/bin/tput cols) - 2` # get terminal width
 num_entries=15
 chart_char='='
 # Get the calling shell
-shell=$(ps -o comm=$PPID | grep $(echo $0 | cut -d"/" -f2-) -B 1 | head -1)
+shell=$(ps -p $PPID -o comm=)
 histfile=$($shell -ci "echo \$HISTFILE")
 OPTIND=1 # reset getopts
 max_len=0

--- a/ginh.sh
+++ b/ginh.sh
@@ -5,7 +5,7 @@ line_len=`expr $(/usr/bin/tput cols) - 2` # get terminal width
 num_entries=15
 chart_char='='
 # Get the calling shell
-shell=$(ps -p $PPID -o comm=)
+shell=$(ps -p $PPID -o comm= | sed -e 's/^-//')
 histfile=$($shell -ci "echo \$HISTFILE")
 OPTIND=1 # reset getopts
 max_len=0

--- a/ginh.sh
+++ b/ginh.sh
@@ -10,6 +10,10 @@ histfile=$($shell -ci "echo \$HISTFILE")
 OPTIND=1 # reset getopts
 max_len=0
 
+# check for zsh extended history format style
+$shell -ci "setopt" |& grep extendedhistory >/dev/null
+zsh_extended_history=$(expr 1 - $?)
+
 function show_help {
   echo "usage: $0 [-h] [-n entries] [-f hist_file] [-c chart_char] [-l line_len]"
 }


### PR DESCRIPTION
Addresses #4 

This checks if the calling shell was zsh, and if it was, checks if zsh's "EXTENDED_HISTORY" option is set, and if it is, then strips out the timestamp information. I think there's probably a better way to execute the "calc"ulations on lines 59 and 62, as they are almost the same. Let me know what you think.

The `sudo` situation is a separate issue.