### PR TITLE
Filters

### DIFF
--- a/ginh.sh
+++ b/ginh.sh
@@ -8,7 +8,7 @@ OPTIND=1 # reset getopts
 max_len=0
 
 zsh_extended_filter_string="^:[0-9 ]*:[0-9];"
-fish_filter_string="^\- cmd: "
+fish_filter_string="^\\- cmd: "
 sudo_filter_string="^sudo "
 
 function show_help() {
@@ -20,13 +20,13 @@ function separator() {
   do
     printf "-"
   done
-  printf "\n"
+  printf "\\n"
 }
 
 # generic shell formatting filter
 function shell_filter() {
-  if grep -E "$2" <<< $1 >/dev/null; then
-    grep -E "$2" <<< $1 \
+  if grep -E "$2" <<< "$1" >/dev/null; then
+    grep -E "$2" <<< "$1" \
       | sed -e "s/$2//g"
   else
     echo "$1"
@@ -45,7 +45,7 @@ function zsh_extended_filter() {
 
 # remove 'sudo's
 function sudo_filter() {
-  sed -e "s/$sudo_filter_string//g" <<< $1
+  sed -e "s/$sudo_filter_string//g" <<< "$1"
 }
 
 # get command name, sort, and count
@@ -149,7 +149,7 @@ for (( n=0; n<=$((num_entries - 1)); n++ )); do
   printf "  "
   printf "%s" "${counts[n]}"
 
-  printf "\n"
+  printf "\\n"
 done
 
 separator

--- a/ginh.sh
+++ b/ginh.sh
@@ -62,12 +62,6 @@ function get_shell() {
   shell=$(ps -p $PPID -o comm= | sed -e 's/^-//')
 }
 
-# check for zsh extended history format style
-function zsh_extended_history() {
-  $shell -ci "setopt" 2>&1 | grep extendedhistory >/dev/null
-  return $?
-}
-
 # get location of history file for the shell used to instantiate ginh
 function get_history_file() {
   get_shell

--- a/ginh.sh
+++ b/ginh.sh
@@ -22,6 +22,16 @@ function separator() {
   printf "\n"
 }
 
+# if match fish history format, remove fish formating
+function fish_filter() {
+  if grep -E "$fish_filter_string" <<< $1 >/dev/null; then
+    grep -E "$fish_filter_string" <<< $1 \
+      | sed -e "s/$fish_filter_string//g"
+  else
+    echo "$1"
+  fi
+}
+
 # check the shell used to instantiate ginh
 function get_shell() {
   shell=$(ps -p $PPID -o comm= | sed -e 's/^-//')

--- a/ginh.sh
+++ b/ginh.sh
@@ -22,14 +22,24 @@ function separator() {
   printf "\n"
 }
 
-# if match fish history format, remove fish formating
-function fish_filter() {
-  if grep -E "$fish_filter_string" <<< $1 >/dev/null; then
-    grep -E "$fish_filter_string" <<< $1 \
-      | sed -e "s/$fish_filter_string//g"
+# generic shell formatting filter
+function shell_filter() {
+  if grep -E "$2" <<< $1 >/dev/null; then
+    grep -E "$2" <<< $1 \
+      | sed -e "s/$2//g"
   else
     echo "$1"
   fi
+}
+
+# if match fish history format, remove fish formating
+function fish_filter() {
+  shell_filter "$1" "$fish_filter_string"
+}
+
+# if match zsh_extended history format, remove zsh_extended formating
+function zsh_extended_filter() {
+  shell_filter "$1" "$zsh_extended_filter_string"
 }
 
 # check the shell used to instantiate ginh

--- a/ginh.sh
+++ b/ginh.sh
@@ -9,6 +9,7 @@ max_len=0
 
 zsh_extended_filter_string="^:[0-9 ]*:[0-9];"
 fish_filter_string="^\- cmd: "
+sudo_filter_string="^sudo "
 
 function show_help() {
   echo "usage: $0 [-h] [-n entries] [-f hist_file] [-c chart_char] [-l line_len]"
@@ -40,6 +41,20 @@ function fish_filter() {
 # if match zsh_extended history format, remove zsh_extended formating
 function zsh_extended_filter() {
   shell_filter "$1" "$zsh_extended_filter_string"
+}
+
+# remove 'sudo's
+function sudo_filter() {
+  sed -e "s/$sudo_filter_string//g" <<< $1
+}
+
+# get command, sort, and count
+function final_filter() {
+  echo "$1" \
+    | awk '{print $1}' \
+    | sort \
+    | uniq -c \
+    | sort -rn
 }
 
 # check the shell used to instantiate ginh

--- a/ginh.sh
+++ b/ginh.sh
@@ -7,6 +7,9 @@ chart_char='='
 OPTIND=1 # reset getopts
 max_len=0
 
+zsh_extended_filter_string="^:[0-9 ]*:[0-9];"
+fish_filter_string="^\- cmd: "
+
 function show_help() {
   echo "usage: $0 [-h] [-n entries] [-f hist_file] [-c chart_char] [-l line_len]"
 }


### PR DESCRIPTION
Refactored how "calc" get's handled to go through a series of filters, including filters to automatically handle if it is a zsh or fish history file. Therefore, fish is now supported (#7) but not automatically detected, so the history file needs to be specified with `-f`. Additionally, added a filter to remove `sudo`, closing #11. We could add a flag to omit that filter, but I don't know if that's of interest to anyone.