### PR TITLE
Add auto-detecting fish shell

### DIFF
--- a/ginh.sh
+++ b/ginh.sh
@@ -65,7 +65,12 @@ function get_shell() {
 # get location of history file for the shell used to instantiate ginh
 function get_history_file() {
   get_shell
-  histfile=$($shell -ci "echo \$HISTFILE")
+  if [ "$shell" == "fish" ]; then
+    # after 2.3.0, fish history is saved here, and cannot be changed
+    histfile=~/.local/share/fish/fish_history
+  else
+    histfile=$($shell -ci "echo \$HISTFILE")
+  fi
 }
 
 get_history_file


### PR DESCRIPTION
According to https://github.com/fish-shell/fish-shell/issues/862, fish shell after 2.3.0 uses one history file location and it cannot be changed. Solves #7 