### PR TITLE
Fix bug with BSD grep

### DIFF
--- a/ginh.sh
+++ b/ginh.sh
@@ -102,7 +102,7 @@ function reverse_aliases_filter() {
     | grep -v "/" \
     | grep -v "='nocorrect" \
     | tr "=" " " \
-    | grep -o "\w\+ '\w\+" \
+    | grep -E -o "[[:alnum:]]+ '[[:alnum:]]+" \
     | tr -d \"\'\(\)\{\" \
     | sed -e 's| |\\\\>\||' \
     | awk '{print $1}' \


### PR DESCRIPTION
**test this on macOS first, I was only able to test using OpenBSD, which showed similar, but not necessarily the exact same, behavior**

BSD grep does not allow \w for "word" characters, but allows the :alnum:
character group. GNU grep also allows the same character group, so by
converting to it it will work on both types of systems.